### PR TITLE
Fix for current pymongo versions

### DIFF
--- a/piconova/mongostore.py
+++ b/piconova/mongostore.py
@@ -1,4 +1,4 @@
-import pymongo
+from pymongo import MongoClient
 import settings
 from scrapy import log
 
@@ -9,7 +9,7 @@ class MongoDBPipeline(object):
         self.db = settings.MONGODB_DB
         self.col = settings.MONGODB_COLLECTION
 
-        connection = pymongo.Connection(self.server, self.port)
+        connection = MongoClient(self.server, self.port)
         db = connection[self.db]
         self.collection = db[self.col]
 


### PR DESCRIPTION
`.Connection` no longer works with pymongo, MongoClient is now used according to [the documentation](http://api.mongodb.com/python/current/tutorial.html)
